### PR TITLE
Update fluentd-elasticsearch to 1.6

### DIFF
--- a/fluentd-elasticsearch/README.md
+++ b/fluentd-elasticsearch/README.md
@@ -14,4 +14,6 @@ These images are versioned in the same way as the base image: [fluentd](https://
 
 ## Supported versions
 
-- `v1.1-debian`, `v1-debian`, `latest`
+- `v1.1-debian`
+- `v1.6-debian`, `v1-debian`, `latest`
+

--- a/fluentd-elasticsearch/v1.6/debian/Dockerfile
+++ b/fluentd-elasticsearch/v1.6/debian/Dockerfile
@@ -1,0 +1,18 @@
+FROM fluent/fluentd:v1.6-debian-1
+
+USER root
+
+RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps \
+ && sudo gem install fluent-plugin-elasticsearch \
+ && sudo gem sources --clear-all \
+ && SUDO_FORCE_REMOVE=yes \
+    apt-get purge -y --auto-remove \
+                  -o APT::AutoRemove::RecommendsImportant=false \
+                  $buildDeps \
+ && rm -rf /var/lib/apt/lists/* \
+           /home/fluent/.gem/ruby/2.3.0/cache/*.gem \
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+
+USER fluent


### PR DESCRIPTION
This pull request makes the following changes:

update to version v1.6-debian